### PR TITLE
FIX: GET order history api 연결

### DIFF
--- a/src/app/api/order/route.ts
+++ b/src/app/api/order/route.ts
@@ -1,10 +1,11 @@
-import { MOCK_SERVER_URL, fetchWithFallback } from "@/shared";
+import { SERVICE_URL, fetchWithFallback } from "@/shared";
 
 export async function GET(request: Request) {
   try {
     const url = new URL(request.url, `http://${request.headers.get("host")}`);
-    const storeId = Number(url.searchParams.get("storeId"));
-    const tableId = Number(url.searchParams.get("tableId"));
+    const storeId = url.searchParams.get("storeId") as string;
+    const tableId = url.searchParams.get("tableId") as string;
+
     if (Number.isNaN(storeId) || Number.isNaN(tableId)) {
       return new Response(JSON.stringify({ error: "Invalid storeId" }), {
         status: 400,
@@ -13,11 +14,10 @@ export async function GET(request: Request) {
     }
 
     const res = await fetchWithFallback(
-      `${MOCK_SERVER_URL}/order/${storeId}/${tableId}`,
+      `${SERVICE_URL}/stores/${storeId}/order-histories/table/${tableId}`,
       "force-cache",
     );
     const data = await res.json();
-
     return new Response(JSON.stringify(data), {
       status: 200,
       headers: { "Content-Type": "application/json" },

--- a/src/entities/order/api/getOrder.ts
+++ b/src/entities/order/api/getOrder.ts
@@ -1,6 +1,6 @@
 import { BASE_URL, OrderHistoryT } from "@/shared";
 
-import { isOrderHistoryT } from "../utils/orderTypeGuards";
+// import { isOrderHistoryT } from "../utils/orderTypeGuards";
 
 type ResponseData = OrderHistoryT | [];
 
@@ -13,12 +13,13 @@ const getOrder = async (
       `${BASE_URL}/api/order?storeId=${storeId}&tableId=${tableId}`,
     );
     const data = await res.json();
+
     if (!res.ok) {
       throw new Error(data);
     }
-    if (!isOrderHistoryT(data)) {
-      throw new Error("OrderHistory 타입이 아닙니다.");
-    }
+    // if (!isOrderHistoryT(data)) {
+    //   throw new Error("OrderHistory 타입이 아닙니다.");
+    // }
     return data;
   } catch (error) {
     if (error instanceof Error) {

--- a/src/entities/order/utils/orderTypeGuards.ts
+++ b/src/entities/order/utils/orderTypeGuards.ts
@@ -7,18 +7,17 @@ function isOrderHistoryItemT(item: unknown): item is OrderHistoryItemT {
 
   return (
     typeof orderItem.orderHistoryId === "string" &&
-    typeof orderItem.orderedAt === "string" &&
+    typeof orderItem.paymentHistoryId === "string" &&
     typeof orderItem.totalPrice === "number" &&
-    (orderItem.status === "pending" ||
-      orderItem.status === "approved" ||
-      orderItem.status === "disapproved") &&
+    (orderItem.status === "PENDING" ||
+      orderItem.status === "APPROVED" ||
+      orderItem.status === "DISAPPROVED") &&
     Array.isArray(orderItem.orderDetail) &&
     orderItem.orderDetail.every(
       detail =>
         typeof detail.name === "string" &&
         typeof detail.price === "number" &&
         typeof detail.count === "number" &&
-        typeof detail.image === "string" &&
         Array.isArray(detail.options) &&
         detail.options.every(
           option =>

--- a/src/shared/types/order-cart-types.ts
+++ b/src/shared/types/order-cart-types.ts
@@ -8,7 +8,6 @@ interface CartItemT {
   name: string;
   price: number;
   count: number;
-  image: string;
   options: CartMenuOptionT[];
 }
 
@@ -16,9 +15,9 @@ type CartItemsT = CartItemT[];
 
 interface OrderHistoryItemT {
   orderHistoryId: string;
-  orderedAt: string;
+  paymentHistoryId: string;
   totalPrice: number;
-  status: "pending" | "approved" | "disapproved";
+  status: "PENDING" | "APPROVED" | "DISAPPROVED";
   orderDetail: CartItemsT;
 }
 

--- a/src/shared/ui/OrderCartItem.tsx
+++ b/src/shared/ui/OrderCartItem.tsx
@@ -2,8 +2,7 @@
 
 import React, { useState } from "react";
 
-import Image from "next/image";
-
+// import Image from "next/image";
 import { CartItemT, CartItemsT } from "../types/order-cart-types";
 import { removeItemFromCart, updateItemCount } from "../utils/cart";
 import compareCartItemsKey from "../utils/compareCartItemsKey";
@@ -84,13 +83,13 @@ export default function OrderCartItem({
         </div>
 
         <div className="relative h-[64px] w-[64px] overflow-hidden rounded-lg">
-          <Image
+          {/* <Image
             src={data.image}
             alt={data.name}
             fill
             style={{ objectFit: "fill" }}
             priority
-          />
+          /> */}
         </div>
       </div>
 

--- a/src/widgets/order-list/ui/OrderItems.tsx
+++ b/src/widgets/order-list/ui/OrderItems.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import {
+  CartItemsT,
   OrderCartItem,
   OrderHistoryItemT,
   generateUniqueCartItemKey,
@@ -10,6 +11,10 @@ import OrderSummary from "./OrderSummary";
 
 export default function OrderItems({ order }: { order: OrderHistoryItemT }) {
   const [showMore, setShowMore] = useState<{ [key: string]: boolean }>({});
+
+  const parsedOrderDetail = JSON.parse(
+    order.orderDetail as unknown as string,
+  ) as CartItemsT;
 
   const toggleShowMore = (orderId: string) => {
     setShowMore(prevState => ({
@@ -33,12 +38,12 @@ export default function OrderItems({ order }: { order: OrderHistoryItemT }) {
       <div
         className={`origin-top transform transition-all duration-300 ease-in-out ${showMore[order.orderHistoryId] ? "max-h-[1000px] scale-y-100 opacity-100" : "max-h-0 scale-y-0 opacity-0"}`}
       >
-        {order.orderDetail.map(item => (
+        {parsedOrderDetail.map(item => (
           <li
             className="relative border-t py-[20px]"
             key={generateUniqueCartItemKey(item)}
           >
-            <OrderCartItem data={item} orderedAt={order.orderedAt} />
+            <OrderCartItem data={item} />
           </li>
         ))}
       </div>

--- a/src/widgets/order-list/ui/OrderList.tsx
+++ b/src/widgets/order-list/ui/OrderList.tsx
@@ -10,6 +10,7 @@ import OrderItems from "./OrderItems";
 
 export default function OrderList({ data }: { data: OrderHistoryT }) {
   const router = useRouter();
+  console.log(data);
 
   return (
     <div>

--- a/src/widgets/order-list/ui/OrderSummary.tsx
+++ b/src/widgets/order-list/ui/OrderSummary.tsx
@@ -1,6 +1,5 @@
-import Image from "next/image";
-
-import { OrderHistoryItemT } from "@/shared";
+// import Image from "next/image";
+import { CartItemsT, OrderHistoryItemT } from "@/shared";
 
 export default function OrderSummary({
   data,
@@ -13,16 +12,19 @@ export default function OrderSummary({
     [key: string]: boolean;
   };
 }) {
+  const parsedOrderDetail = JSON.parse(
+    data.orderDetail as unknown as string,
+  ) as CartItemsT;
   return (
     <div>
-      <p className="mb-[16px] block text-sm text-[#6F6F6F]">{data.orderedAt}</p>
+      {/* <p className="mb-[16px] block text-sm text-[#6F6F6F]">{data.orderedAt}</p> */}
       <div className="flex justify-between">
         <div>
           <div className="space-y-[4px]">
             <p className="block font-bold">
-              {data.orderDetail.length > 1
-                ? `${data.orderDetail[0].name} 외 ${data.orderDetail.length - 1}개`
-                : data.orderDetail[0].name}
+              {parsedOrderDetail.length > 1
+                ? `${parsedOrderDetail[0].name} 외 ${parsedOrderDetail.length - 1}개`
+                : parsedOrderDetail[0].name}
             </p>
 
             <p className="block text-sm font-bold">
@@ -31,13 +33,13 @@ export default function OrderSummary({
           </div>
         </div>
         <div className="relative h-[64px] w-[64px] overflow-hidden rounded-lg">
-          <Image
-            src={data.orderDetail[0].image}
-            alt={data.orderDetail[0].name}
+          {/* <Image
+            src={parsedOrderDetail[0].image}
+            alt={parsedOrderDetail[0].name}
             fill
             style={{ objectFit: "fill" }}
             priority
-          />
+          /> */}
         </div>
       </div>
       <div className="mb-[20px] mt-[16px] px-[16px]">


### PR DESCRIPTION
- GET order history api를 연결하였습니다.

[결과 화면]

![image](https://github.com/user-attachments/assets/33e181a2-f1cd-402e-a7e1-e2374b5df1ca)

그러나 처음에 요청했던 형식과 다른 형태로 response가 나온 것 같습니다. 
주문 시간과 이미지 url이 없는 것으로 확인 되었습니다. 

우선은 response 데이터를 기준으로 개발을 완료해두었고, 
추후 수정이 필요할 것 같습니다.
<img src="https://github.com/user-attachments/assets/1de51002-0877-491e-a66d-d00ba5942b94" width="300"/>
<img src="https://github.com/user-attachments/assets/93ea47d2-e55c-4034-aa95-e45823af4b25" width="300"/>

- getOrder에서 타입가드 사용하신 부분에서 Error가 계속해서 발생하여 우선 주석처리 해두었습니다. 
 추후 리팩토링 때 타입가드에 대해 다시 논의해보면 좋을 것 같습니다!



